### PR TITLE
Fix possible error with empty character at the end of file

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import time
 import requests
 from rich.console import Console
 
-cookie = pathlib.Path("cookie.txt").read_text()
+cookie = pathlib.Path("cookie.txt").read_text().strip()
 
 session = requests.Session()
 session.cookies.update({".ROBLOSECURITY": cookie})


### PR DESCRIPTION
I had issues, showing me that I had an invalid header (the login cookie) and after researching a bit, it was adding, somehow, a `\n` at the end and making that header not valid.

The solution is to add `.strip()`, and will fix it for everyone having this issue